### PR TITLE
docs(plugins): fix URL for try plugin

### DIFF
--- a/docs/plugins/ui/apps/examples.md
+++ b/docs/plugins/ui/apps/examples.md
@@ -35,7 +35,7 @@ app.changeNavBarColor('#8e6a3a');
 
 <ButtonsTrySource
     product="app"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/wda/sidebar-color/manifest.json"
+    manifest="https://developers.wazo.io/examples/wda/sidebar-color/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/wda/sidebar-color"
 />
 
@@ -65,7 +65,7 @@ await app.initialize();
 
 <ButtonsTrySource
     product="app"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/wda/incoming-call-modal/manifest.json"
+    manifest="https://developers.wazo.io/examples/wda/incoming-call-modal/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/wda/incoming-call-modal"
 />
 
@@ -141,7 +141,7 @@ app.initialize();
 
 <ButtonsTrySource
     product="app"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/wda/iframe-bg-messaging/manifest.json"
+    manifest="https://developers.wazo.io/examples/wda/iframe-bg-messaging/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/wda/iframe-bg-messaging"
 />
 
@@ -173,7 +173,7 @@ app.initialize();
 
 <ButtonsTrySource
     product="app"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/wda/settings-menu/manifest.json"
+    manifest="https://developers.wazo.io/examples/wda/settings-menu/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/wda/settings-menu"
 />
 
@@ -219,7 +219,7 @@ app.onCallAnswered = (call) => {
 
 <ButtonsTrySource
     product="app"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/wda/video-pip/manifest.json"
+    manifest="https://developers.wazo.io/examples/wda/video-pip/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/wda/video-pip"
 />
 
@@ -241,6 +241,6 @@ setTimeout(() => {
 
 <ButtonsTrySource
     product="app"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/wda/configure-sounds/manifest.json"
+    manifest="https://developers.wazo.io/examples/wda/configure-sounds/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/wda/configure-sounds"
 />

--- a/docs/plugins/ui/portal/examples.md
+++ b/docs/plugins/ui/portal/examples.md
@@ -27,7 +27,7 @@ document.getElementById('name').innerHTML = context.app.extra.record.auth.userna
 
 <ButtonsTrySource
     product="portal"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/portal/pbx-dashboard-tab/manifest.json"
+    manifest="https://developers.wazo.io/examples/portal/pbx-dashboard-tab/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/portal/pbx-dashboard-tab"
 />
 
@@ -55,7 +55,7 @@ document.getElementById('name').innerHTML = context.app.extra.record.auth.userna
 
 <ButtonsTrySource
     product="portal"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/portal/pbx-user-form-tab/manifest.json"
+    manifest="https://developers.wazo.io/examples/portal/pbx-user-form-tab/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/portal/pbx-user-form-tab"
 />
 

--- a/docs/plugins/ui/templates.md
+++ b/docs/plugins/ui/templates.md
@@ -51,7 +51,7 @@ This template uses vanilla Javascript, HTML and [Materialize](https://materializ
 
 <ButtonsTrySource
     product="portal"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/portal/css/manifest.json"
+    manifest="https://developers.wazo.io/examples/portal/css/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/portal/css/materializecss.html"
 />
 
@@ -69,7 +69,7 @@ This template uses vanilla Javascript, HTML and [MUI (css)](https://www.muicss.c
 
 <ButtonsTrySource
     product="portal"
-    manifest="https://wazo-communication.github.io/developers.wazo.io/examples/portal/css/manifest.json"
+    manifest="https://developers.wazo.io/examples/portal/css/manifest.json"
     source="https://github.com/wazo-communication/developers.wazo.io/tree/main/static/examples/portal/css/muicss.html"
 />
 


### PR DESCRIPTION
## Summary Changes

We have CORS issue when Github Page URL. Point `manifest.json` to developers.wazo.io solve the issue.

![Capture d’écran, le 2024-09-26 à 15 49 42](https://github.com/user-attachments/assets/06de07df-a6a6-4d34-aa2c-c6be3bd0fe15)
