### PR TITLE
docs(wda): more emphase on the white svg icon

### DIFF
--- a/docs/plugins/ui/apps/index.md
+++ b/docs/plugins/ui/apps/index.md
@@ -16,7 +16,7 @@ Apps plugins allow many great ways to extend the interface. Here's a quick summa
 - Extend Settings pannel
 - Run code logic inside a background script
 
-## Tabs - Add menu item (dashbaord)
+## Tabs - Add menu item (dashboard)
 
 ![App configuration](/img/plugins/ui/app/wda-tab-example.png)
 
@@ -40,7 +40,8 @@ When the user clicks on the tab, the `contentUrl` will be loaded.
 
 ![App configuration (small)](/img/plugins/ui/app/wda-sidebar.png)
 
-To create a new tab in the main screen, add a `staticTabs` in your manifest with a `sidebarTab` `context` :
+To create a new tab in the main screen, add a `staticTabs` in your manifest with a `sidebarTab` `context`.
+
 ```json
 "staticTabs": [
   {
@@ -55,9 +56,12 @@ To create a new tab in the main screen, add a `staticTabs` in your manifest with
 ],
 ```
 
-The `icon` should be a white `svg` file for better results.
+:::info
+For optimal results, `icon` must be a **white** SVG. `<svg fill="#FFF" />`
+:::
 
 When the user clicks on the tab, the `contentUrl` will be loaded.
+
 
 ## Tabs - Add menu item (contact)
 


### PR DESCRIPTION
## Summary

- Make it clearer to use a white svg for WDA plugins


![Capture d’écran, le 2024-11-20 à 12 03 38](https://github.com/user-attachments/assets/2c21c2ed-83a2-484a-aa47-cf6a04582b90)
